### PR TITLE
Agent-feedback improvements: docs, enriched lldb_start, new lldb_restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@ MCP client  <--stdio MCP-->  rust-lldb-mcp  <--Unix socket MCP-->  rust-lldb
 
 `lldb_start` spawns `rust-lldb`, loads the target, runs any preload commands,
 and opens LLDB's built-in `protocol-server start MCP` on a per-session Unix
-socket. `lldb_command` proxies LLDB commands over that socket. `lldb_stop`
-tears it all down. Idle cost: zero.
+socket. `lldb_command` proxies LLDB commands over that socket.
+`lldb_restart` tears down and respawns in one call (useful for advancing past
+a breakpoint when LLDB's MCP can't handle `continue`). `lldb_stop` tears it
+all down. Idle cost: zero.
 
 ## Why this exists
 
@@ -52,9 +54,9 @@ claude mcp list | grep rust-lldb   # should show "✓ Connected"
 ```
 
 Start a fresh Claude Code session; `mcp__rust_lldb__lldb_start`,
-`mcp__rust_lldb__lldb_command`, and `mcp__rust_lldb__lldb_stop` appear
-in the toolbox. The tool surface is driven entirely by this project; no
-per-project configuration is needed.
+`mcp__rust_lldb__lldb_command`, `mcp__rust_lldb__lldb_restart`, and
+`mcp__rust_lldb__lldb_stop` appear in the toolbox. The tool surface is
+driven entirely by this project; no per-project configuration is needed.
 
 ### Smoke test
 
@@ -62,9 +64,10 @@ per-project configuration is needed.
 node smoke-test.js
 ```
 
-Exercises the three tools against `/bin/ls`, the `process_command_rejected`
+Exercises the four tools against `/bin/ls`, the `process_command_rejected`
 guardrail, typical failure modes (`binary_not_found`, `session_not_found`,
-double-stop), and the socket-wait timeout path. The last part builds a tiny
+double-stop), the restart-chain (old id invalidated, new preload carried
+over), and the socket-wait timeout path. The last part builds a tiny
 C binary with `cc -g` that sleeps during preload, so the host needs `cc`
 (clang on macOS, gcc on Linux — both are usually already present) on
 `PATH`. Expect all green; after exit, `/tmp/rust-lldb-mcp.*.sock`
@@ -72,7 +75,7 @@ should be empty and `pgrep -f rust-lldb` should return nothing.
 
 ## Tool surface
 
-### `lldb_start({ binary?, core?, preload?, socket_wait_ms? }) → { session_id }`
+### `lldb_start({ binary?, core?, preload?, socket_wait_ms? }) → { session_id, binary, core, preload_count, stop_summary }`
 
 Spawn a new `rust-lldb` and load the target. At least one of `binary`
 (path to an executable) or `core` (path to a core dump) is required.
@@ -89,6 +92,15 @@ slow-to-start debug build eats the default. Default 5000, clamped to
 `invalid_request`. The `LLDB_MCP_SOCKET_WAIT_MS` env var on the
 orchestrator process is a fallback when the argument is absent.
 
+`stop_summary` in the return payload is a best-effort one-line
+description of the inferior state after preload (e.g.
+`"Process 12345 stopped — frame #0 myapp\`main at main.rs:42"`,
+`"Process 12345 exited with status = 0"`, `"target loaded (no process)"`)
+so callers can confirm their preload landed where expected without a
+separate `process status` round-trip. `binary` / `core` are echoed back
+verbatim (or `null` when absent) and `preload_count` is the number of
+preload entries used.
+
 Errors (`code` field in the error payload): `invalid_request`,
 `binary_not_found`, `core_not_found`, `lldb_spawn_failed`,
 `socket_never_appeared`, `initialize_failed`, `target_create_failed`,
@@ -104,6 +116,34 @@ dropped …]` footer and `truncated: true, dropped_chars: N` metadata.
 
 Errors: `session_not_found`, `lldb_crashed`, `timeout`, `lldb_rpc_error`,
 `process_command_rejected`.
+
+### `lldb_restart({ session_id, preload? }) → { session_id, previous_session_id, binary, core, preload_count, stop_summary }`
+
+Tear down an existing session and spawn a fresh one against the same
+`binary` / `core` in a single call. Use when you need to resume past a
+breakpoint, change the preload (e.g. move the breakpoint, add a new
+one), or re-run to the same stop: the orchestrator's cheap spawn
+semantics make this the preferred alternative to the `process continue`
+/ `step` commands that hang LLDB's MCP server.
+
+`preload` overrides the previous session's preload when provided;
+otherwise the previous preload is reused verbatim (convenient for
+"re-run to the same breakpoint"). `socket_wait_ms` is inherited from
+the previous session — a slow preload that succeeded once will succeed
+again on restart.
+
+The returned `session_id` is **always fresh** — the old id is
+invalidated atomically, before teardown begins, so any concurrent
+`lldb_command` on the old id gets a clean `session_not_found` rather
+than racing a half-torn-down session. `previous_session_id` echoes the
+old id for traceability. The rest of the payload matches `lldb_start`.
+
+Errors: `session_not_found` (old id unknown), `invalid_request` (bad
+`preload`), plus everything `lldb_start` can return when the respawn
+fails (`binary_not_found`, `core_not_found`, `lldb_spawn_failed`,
+`socket_never_appeared`, `initialize_failed`, `target_create_failed`,
+`too_many_sessions`). On respawn failure, the old session is already
+gone — call `lldb_start` fresh.
 
 ### `lldb_stop({ session_id }) → { ok: true }`
 
@@ -127,8 +167,12 @@ already at a known stop. The orchestrator rejects the same commands from
 `lldb_command` with a typed `process_command_rejected` error, steering
 callers at the fix.
 
-To resume (step, continue), `lldb_stop` the current session and
-`lldb_start` a new one with updated `preload`.
+To resume (step, continue, re-run past a breakpoint), call
+`lldb_restart({ session_id, preload: [...new commands..., "run"] })`:
+it tears down the current session and spawns a fresh one against the
+same binary/core in one call, returning a new `session_id`. Omit
+`preload` to reuse the previous preload verbatim. `lldb_stop` +
+`lldb_start` still works and is the right tool when switching binaries.
 
 ## Example: debug a Rust panic
 

--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ claude mcp add --scope user rust-lldb -- "$PWD/index.js"
 claude mcp list | grep rust-lldb   # should show "✓ Connected"
 ```
 
-Start a fresh Claude Code session; `mcp__rust_lldb__lldb_start`,
-`mcp__rust_lldb__lldb_command`, `mcp__rust_lldb__lldb_restart`, and
-`mcp__rust_lldb__lldb_stop` appear in the toolbox. The tool surface is
+Start a fresh Claude Code session; `mcp__rust-lldb__lldb_start`,
+`mcp__rust-lldb__lldb_command`, `mcp__rust-lldb__lldb_restart`, and
+`mcp__rust-lldb__lldb_stop` appear in the toolbox. The tool surface is
 driven entirely by this project; no per-project configuration is needed.
 
 ### Smoke test

--- a/index.js
+++ b/index.js
@@ -61,6 +61,10 @@ class Session {
         this.dead = false;
         this.nextRequestId = 1;
         this.closing = false;
+        // Populated by startSession after a successful spawn. Captures the
+        // arguments the caller supplied so lldb_restart can reuse them without
+        // requiring the caller to re-state binary/core/socket_wait_ms.
+        this.startArgs = null;
     }
 
     nextId() {
@@ -391,7 +395,65 @@ async function startSession({ binary, core, preload, socket_wait_ms }) {
         );
     }
 
-    return { session_id: id };
+    session.startArgs = {
+        binary: binary || null,
+        core: core || null,
+        preload: Array.isArray(preload) ? [...preload] : [],
+        socket_wait_ms: socket_wait_ms ?? null,
+    };
+    const preloadCount = session.startArgs.preload.length;
+    const stopSummary = await probeStopSummary(session);
+
+    return {
+        session_id: id,
+        binary: session.startArgs.binary,
+        core: session.startArgs.core,
+        preload_count: preloadCount,
+        stop_summary: stopSummary,
+    };
+}
+
+// Best-effort one-line summary of the session's current inferior state,
+// included in lldb_start / lldb_restart returns so callers don't need a
+// separate `process status` round-trip to know whether their preload
+// actually stopped at a breakpoint. Never fails the enclosing call:
+// any parse or RPC failure becomes "unknown".
+async function probeStopSummary(session) {
+    let statusOut;
+    try {
+        statusOut = await runLldbCommand(session, 'process status');
+    } catch {
+        return 'unknown';
+    }
+    const firstLine = (statusOut || '')
+        .split('\n')
+        .map(l => l.trim())
+        .find(l => l.length > 0) || '';
+    if (!firstLine) return 'target loaded (no process)';
+    // "error: invalid process" (LLDB 21), "error: Command requires a current
+    // process." (Apple LLDB) — both mean "target is loaded but nothing has run
+    // yet." Normalize to a single opaque phrase.
+    if (/^error:.*(invalid process|current process|no process)/i.test(firstLine)) {
+        return 'target loaded (no process)';
+    }
+    if (/^Process\s+\d+\s+stopped/i.test(firstLine)) {
+        // Append file:line from `frame info` when available — turns
+        // "Process 12345 stopped" into
+        // "Process 12345 stopped at parser.rs:42 (frame #0 myapp::parse)".
+        let frameDetail = '';
+        try {
+            const frameOut = await runLldbCommand(session, 'frame info');
+            const frameLine = (frameOut || '')
+                .split('\n')
+                .map(l => l.trim())
+                .find(l => l.length > 0) || '';
+            if (frameLine) frameDetail = ` — ${frameLine}`;
+        } catch {
+            // Leave frameDetail empty on error.
+        }
+        return `${firstLine}${frameDetail}`;
+    }
+    return firstLine;
 }
 
 function shellQuote(s) {
@@ -561,7 +623,7 @@ server.registerTool(
     'lldb_start',
     {
         description:
-            'Spawn a new rust-lldb session. Provide `binary` (path to executable) and/or `core` (path to core dump). `preload` is an optional list of LLDB commands to run before the MCP server takes over — use it to set breakpoints and launch the target to a stopped state (e.g. ["breakpoint set --name rust_panic", "run"]). Process-executing commands (run, continue, process launch/kill, step) hang if issued via lldb_command, so put them in preload instead. Preload commands run to completion before the MCP socket appears — a slow `run` against a debug build counts against the socket-wait budget; raise `socket_wait_ms` (or set the LLDB_MCP_SOCKET_WAIT_MS env var) when the default 5000 ms is tight. Returns { session_id } for use with lldb_command/lldb_stop.',
+            'Debugger for Rust binaries, tests, and core dumps. Spawn a new rust-lldb session to set breakpoints, debug panics or segfaults, inspect stack frames and variables post-mortem. Provide `binary` (path to executable) and/or `core` (path to core dump). `preload` is an optional list of LLDB commands to run before the MCP server takes over — use it to set breakpoints and launch the target to a stopped state (e.g. ["breakpoint set --name rust_panic", "run"]). Process-executing commands (run, continue, process launch/kill, step) hang if issued via lldb_command, so put them in preload instead. Preload commands run to completion before the MCP socket appears — a slow `run` against a debug build counts against the socket-wait budget; raise `socket_wait_ms` (or set the LLDB_MCP_SOCKET_WAIT_MS env var) when the default 5000 ms is tight. Returns { session_id, binary, core, preload_count, stop_summary } where stop_summary is a best-effort one-liner about the inferior state (e.g. "Process 12345 stopped — frame #0 ...").',
         inputSchema: {
             binary: z.string().optional().describe('Path to an executable to debug.'),
             core: z.string().optional().describe('Path to a core dump.'),
@@ -595,7 +657,7 @@ server.registerTool(
     'lldb_command',
     {
         description:
-            'Run an LLDB command in an existing session. The command string is passed to LLDB exactly as typed at the (lldb) prompt. Returns { output, truncated?, dropped_chars? }. Note: LLDB\'s `breakpoint set --condition` evaluator is unreliable for Rust struct-field access (e.g. `self.field == 42` silently evaluates-true on every hit); prefer `--ignore-count N`, `--one-shot true`, `$__lldb_hitcount == N`, or plain register/address equality.',
+            'Debugger command: run any LLDB command in an existing session to set breakpoints, inspect stack frames, read variables, disassemble, or query process state. The command string is passed to LLDB exactly as typed at the (lldb) prompt. Returns { output, truncated?, dropped_chars? }. Note: LLDB\'s `breakpoint set --condition` evaluator is unreliable for Rust struct-field access (e.g. `self.field == 42` silently evaluates-true on every hit); prefer `--ignore-count N`, `--one-shot true`, `$__lldb_hitcount == N`, or plain register/address equality.',
         inputSchema: {
             session_id: z.number().int().describe('Session id returned by lldb_start.'),
             command: z.string().describe('LLDB command string (e.g. "bt 10", "frame variable foo").'),
@@ -615,7 +677,7 @@ server.registerTool(
     'lldb_stop',
     {
         description:
-            'Tear down an LLDB session, killing the rust-lldb process and removing its Unix socket.',
+            'Debugger shutdown: tear down an LLDB session, killing the rust-lldb process and removing its Unix socket. Call this when finished debugging a Rust binary or core dump.',
         inputSchema: {
             session_id: z.number().int().describe('Session id returned by lldb_start.'),
         },

--- a/index.js
+++ b/index.js
@@ -542,7 +542,7 @@ async function commandSession({ session_id, command }) {
     if (classifyCommand(command) === 'hang') {
         throw new LldbError(
             'process_command_rejected',
-            `"${command}" resumes the inferior, which hangs LLDB's MCP server. Put it in lldb_start({preload:[...]}) to run it before MCP takes over, or call lldb_stop and restart the session with an updated preload.`,
+            `"${command}" resumes the inferior, which hangs LLDB's MCP server. Put it in lldb_start({preload:[...]}) to run it before MCP takes over, or call lldb_restart({session_id, preload:[...]}) to respawn the session with an updated preload.`,
         );
     }
     const output = await runLldbCommand(session, command);
@@ -586,6 +586,68 @@ async function stopSession({ session_id }) {
     sessions.delete(session_id);
     await teardownSession(session);
     return { ok: true };
+}
+
+// Tear down an existing session and spawn a fresh one against the same
+// binary/core. Mints a new session_id — never reuses the old one — so
+// pid aliasing and "same id, different process" telemetry confusion are
+// avoided. Returns the same enriched payload shape as lldb_start, plus
+// `previous_session_id` for traceability.
+async function restartSession({ session_id, preload }) {
+    const session = sessions.get(session_id);
+    if (!session) {
+        throw new LldbError('session_not_found', `no such session: ${session_id}`);
+    }
+    if (preload !== undefined && preload !== null && !Array.isArray(preload)) {
+        throw new LldbError('invalid_request', 'preload must be an array of strings');
+    }
+    const prev = session.startArgs;
+    if (!prev) {
+        // Should not happen — startArgs is populated before the session is
+        // inserted into the map. Guard just in case.
+        throw new LldbError(
+            'internal_error',
+            `session ${session_id} has no recorded start args; cannot restart`,
+        );
+    }
+    // Atomic handoff: remove the old id from the map *before* awaiting
+    // teardown, so any concurrent lldb_command on the old id gets a clean
+    // session_not_found instead of racing against a half-torn-down session.
+    sessions.delete(session_id);
+    await teardownSession(session);
+
+    const nextPreload = preload !== undefined && preload !== null
+        ? preload
+        : prev.preload;
+    const spawnArgs = {
+        binary: prev.binary ?? undefined,
+        core: prev.core ?? undefined,
+        preload: nextPreload,
+    };
+    if (prev.socket_wait_ms !== null && prev.socket_wait_ms !== undefined) {
+        spawnArgs.socket_wait_ms = prev.socket_wait_ms;
+    }
+    let started;
+    try {
+        started = await startSession(spawnArgs);
+    } catch (err) {
+        // Old session is gone; respawn failed. Surface the error with the
+        // previous id annotated so the caller can tie the failure back to
+        // the restart call site.
+        if (err instanceof LldbError) {
+            err.details = { ...(err.details || {}), previous_session_id: session_id };
+            throw err;
+        }
+        throw new LldbError(
+            'internal_error',
+            `lldb_restart respawn failed after teardown of session ${session_id}: ${err.message}`,
+            { previous_session_id: session_id },
+        );
+    }
+    return {
+        ...started,
+        previous_session_id: session_id,
+    };
 }
 
 async function shutdownAll() {
@@ -687,6 +749,31 @@ server.registerTool(
             return toToolResult(await stopSession(args));
         } catch (err) {
             log(`lldb_stop failed (session=${args.session_id}):`, err.code || '', err.message);
+            return toToolError(err);
+        }
+    },
+);
+
+server.registerTool(
+    'lldb_restart',
+    {
+        description:
+            'Debugger restart: tear down an existing rust-lldb session and spawn a fresh one against the same binary or core dump, optionally with a new preload (e.g. "move the breakpoint, re-run to the next site"). Reuses the previous preload when `preload` is omitted. Always returns a fresh session_id — the old id is invalidated. Use this instead of lldb_stop + lldb_start when you need to resume execution past breakpoint hits, since process-executing commands (continue, step, run) hang if issued via lldb_command.',
+        inputSchema: {
+            session_id: z.number().int().describe('Session id returned by a prior lldb_start/lldb_restart.'),
+            preload: z
+                .array(z.string())
+                .optional()
+                .describe(
+                    'Optional new preload for the respawned session. When omitted, the previous session\'s preload is reused verbatim.',
+                ),
+        },
+    },
+    async (args) => {
+        try {
+            return toToolResult(await restartSession(args));
+        } catch (err) {
+            log(`lldb_restart failed (session=${args.session_id}):`, err.code || '', err.message);
             return toToolError(err);
         }
     },

--- a/index.js
+++ b/index.js
@@ -595,7 +595,7 @@ server.registerTool(
     'lldb_command',
     {
         description:
-            'Run an LLDB command in an existing session. The command string is passed to LLDB exactly as typed at the (lldb) prompt. Returns { output, truncated?, dropped_chars? }.',
+            'Run an LLDB command in an existing session. The command string is passed to LLDB exactly as typed at the (lldb) prompt. Returns { output, truncated?, dropped_chars? }. Note: LLDB\'s `breakpoint set --condition` evaluator is unreliable for Rust struct-field access (e.g. `self.field == 42` silently evaluates-true on every hit); prefer `--ignore-count N`, `--one-shot true`, `$__lldb_hitcount == N`, or plain register/address equality.',
         inputSchema: {
             session_id: z.number().int().describe('Session id returned by lldb_start.'),
             command: z.string().describe('LLDB command string (e.g. "bt 10", "frame variable foo").'),

--- a/smoke-test.js
+++ b/smoke-test.js
@@ -159,6 +159,14 @@ async function main() {
         const sid = started.value?.session_id;
         if (typeof sid === 'number') ok(`lldb_start -> session_id=${sid}`);
         else { bad(`no session_id: ${JSON.stringify(started)}`); failures++; throw new Error('cannot proceed'); }
+        if (started.value?.binary === '/bin/ls' &&
+            started.value?.preload_count === 0 &&
+            started.value?.stop_summary === 'target loaded (no process)') {
+            ok(`enriched payload: binary=${started.value.binary}, preload_count=${started.value.preload_count}, stop_summary="${started.value.stop_summary}"`);
+        } else {
+            bad(`enriched payload missing/wrong: ${JSON.stringify(started.value)}`);
+            failures++;
+        }
 
         info('lldb_command: breakpoint set --name main');
         const bp = parseToolResult(await request('tools/call', {

--- a/smoke-test.js
+++ b/smoke-test.js
@@ -138,7 +138,7 @@ async function main() {
         info('tools/list');
         const tools = await request('tools/list', {});
         const names = (tools?.tools || []).map(t => t.name).sort();
-        const expected = ['lldb_command', 'lldb_start', 'lldb_stop'];
+        const expected = ['lldb_command', 'lldb_restart', 'lldb_start', 'lldb_stop'];
         if (JSON.stringify(names) === JSON.stringify(expected)) ok(`tools/list: ${names.join(', ')}`);
         else { bad(`tools/list: got ${JSON.stringify(names)}, want ${JSON.stringify(expected)}`); failures++; }
 
@@ -224,6 +224,113 @@ async function main() {
         }));
         if (stopAgain.isError && stopAgain.value?.code === 'session_not_found') ok('double-stop surfaced session_not_found');
         else { bad(`expected session_not_found on double-stop, got: ${JSON.stringify(stopAgain)}`); failures++; }
+
+        // --- Restart scenarios ---
+        //
+        // lldb_restart should tear down the old session, spawn a fresh
+        // one against the same binary, mint a new session_id, and echo
+        // previous_session_id. The old id should then reject commands
+        // with session_not_found.
+
+        info('lldb_start (for restart test)');
+        const preRestart = parseToolResult(await request('tools/call', {
+            name: 'lldb_start',
+            arguments: { binary: '/bin/ls' },
+        }, 15000));
+        const sidA = preRestart.value?.session_id;
+        if (typeof sidA !== 'number') {
+            bad(`restart setup failed: ${JSON.stringify(preRestart)}`);
+            failures++;
+        } else {
+            ok(`restart setup -> session_id=${sidA}`);
+
+            info('lldb_restart with new preload -> fresh session_id');
+            const restarted = parseToolResult(await request('tools/call', {
+                name: 'lldb_restart',
+                arguments: {
+                    session_id: sidA,
+                    preload: ['breakpoint set --name main'],
+                },
+            }, 15000));
+            const sidB = restarted.value?.session_id;
+            if (!restarted.isError &&
+                typeof sidB === 'number' &&
+                sidB !== sidA &&
+                restarted.value?.previous_session_id === sidA &&
+                restarted.value?.binary === '/bin/ls' &&
+                restarted.value?.preload_count === 1) {
+                ok(`lldb_restart -> session_id=${sidB}, previous_session_id=${sidA}`);
+            } else {
+                bad(`lldb_restart unexpected: ${JSON.stringify(restarted)}`);
+                failures++;
+            }
+
+            if (typeof sidB === 'number') {
+                info('lldb_command on old session_id -> session_not_found');
+                const onOld = parseToolResult(await request('tools/call', {
+                    name: 'lldb_command',
+                    arguments: { session_id: sidA, command: 'version' },
+                }));
+                if (onOld.isError && onOld.value?.code === 'session_not_found') {
+                    ok('old session_id rejected after restart');
+                } else {
+                    bad(`expected session_not_found on old id, got: ${JSON.stringify(onOld)}`);
+                    failures++;
+                }
+
+                info('lldb_command on new session: breakpoint list reflects new preload');
+                const bpList = parseToolResult(await request('tools/call', {
+                    name: 'lldb_command',
+                    arguments: { session_id: sidB, command: 'breakpoint list' },
+                }));
+                if (!bpList.isError &&
+                    typeof bpList.value?.output === 'string' &&
+                    /main/i.test(bpList.value.output)) {
+                    ok('new session carries restart-provided breakpoint');
+                } else {
+                    bad(`breakpoint list unexpected: ${JSON.stringify(bpList)}`);
+                    failures++;
+                }
+
+                info('lldb_restart with no preload reuses previous preload');
+                const restarted2 = parseToolResult(await request('tools/call', {
+                    name: 'lldb_restart',
+                    arguments: { session_id: sidB },
+                }, 15000));
+                const sidC = restarted2.value?.session_id;
+                if (!restarted2.isError &&
+                    typeof sidC === 'number' &&
+                    sidC !== sidB &&
+                    restarted2.value?.preload_count === 1) {
+                    ok(`lldb_restart (no preload arg) reuses previous -> session_id=${sidC}`);
+                } else {
+                    bad(`lldb_restart (reuse) unexpected: ${JSON.stringify(restarted2)}`);
+                    failures++;
+                }
+
+                if (typeof sidC === 'number') {
+                    info(`lldb_stop restart-chain session ${sidC}`);
+                    const stopC = parseToolResult(await request('tools/call', {
+                        name: 'lldb_stop',
+                        arguments: { session_id: sidC },
+                    }, 5000));
+                    if (!stopC.isError && stopC.value?.ok === true) ok('lldb_stop (restart chain) OK');
+                    else { bad(`lldb_stop (restart chain) unexpected: ${JSON.stringify(stopC)}`); failures++; }
+                }
+            }
+
+            info('lldb_restart on already-stopped session -> session_not_found');
+            const restartDead = parseToolResult(await request('tools/call', {
+                name: 'lldb_restart',
+                arguments: { session_id: sidA },
+            }));
+            if (restartDead.isError && restartDead.value?.code === 'session_not_found') {
+                ok('restart of gone session surfaced session_not_found');
+            } else {
+                bad(`expected session_not_found on gone id, got: ${JSON.stringify(restartDead)}`);
+                failures++;
+            }
+        }
 
         // --- Slow preload scenarios (real-workload shape) ---
         //


### PR DESCRIPTION
Closes #5.

Four commits responding to agent-session feedback (tracking issue #5
has the full context and maps feedback → commit):

- `b777bc0` — doc-only warning on `lldb_command` about Rust
  `--condition` unreliability.
- `0d0a59c` — keyword-dense tool descriptions + enriched `lldb_start`
  return with `stop_summary` derived from a post-handshake probe.
- `b1d7587` — new `lldb_restart` tool; atomic old-id invalidation,
  fresh `session_id`, `previous_session_id` echoed.
- `20071b3` — fix latent doc bug: tool prefix is `mcp__rust-lldb__`
  (hyphen preserved from the MCP id), not the underscored form
  previously documented.

Deferred items split out into sub-issues #2, #3, #4 under the tracking
issue.

## Testing beyond `node smoke-test.js`

Smoke test covers everything committed (enriched payload, restart
chain, old-id rejection, preload reuse, respawn-after-gone). Manual
end-to-end against a real Rust binary via the `lldb-debug` skill is
still TODO; it's the only signal that `stop_summary` parsing is
robust against real debug-build output, and it's not automatable
without a Rust fixture in the repo — if that's worth it, a follow-up
could add `testdata/panic.rs` and extend the smoke test.