### PR TITLE
Portability fixes + CI hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      npm-minor-and-patch:
+        update-types: [minor, patch]
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions-minor-and-patch:
+        update-types: [minor, patch]
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,73 @@
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# Least-privilege: every job is read-only against the repo and has no secrets
+# exposed. Elevate per-job/per-step only when a future workflow genuinely needs
+# write access.
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        # Pinned by full commit SHA (not tag): prevents a compromised tag
+        # from silently shipping new code. Dependabot (github-actions
+        # ecosystem) updates these pins automatically.
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Node.js 20
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Set up Rust stable
+        # Provides `rustup`, which brings the `rust-lldb` wrapper script that
+        # the orchestrator spawns.
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - name: Install LLDB 21
+        # apt.llvm.org's helper script is piped to sudo bash. We accept this
+        # residual risk deliberately: it runs only on the ephemeral runner,
+        # never reaches user workstations or published artifacts, and there
+        # is no stable upstream sha256 for llvm.sh. Tracked for revisit.
+        run: |
+          wget -qO llvm.sh https://apt.llvm.org/llvm.sh
+          sudo bash llvm.sh 21
+          sudo update-alternatives --install /usr/bin/lldb lldb /usr/bin/lldb-21 100
+          lldb --version
+
+      - name: Verify rust-lldb + protocol-server
+        # Fast-fail: if this probe doesn't print "MCP server started …", the
+        # smoke test is guaranteed to fail downstream. Surfacing it here keeps
+        # the failure message actionable.
+        run: |
+          which rust-lldb
+          rust-lldb -b -o "protocol-server start MCP accept:///tmp/probe.sock" -o "protocol-server stop MCP"
+
+      - name: Install npm dependencies
+        # `npm ci` respects package-lock.json and verifies SHA-512 tarball
+        # integrity on every install — unlike `npm install`, which may widen
+        # ranges or skip lockfile checks.
+        run: npm ci
+
+      - name: Lint (biome ci)
+        run: npm run lint
+
+      - name: Unit tests
+        run: npm test
+
+      - name: npm audit (advisory)
+        # Advisory-only for now. Promote to blocking after one clean run —
+        # tracked in the productization issue.
+        run: npm audit --omit=dev --audit-level=high
+        continue-on-error: true
+
+      - name: Smoke test (end-to-end)
+        run: npm run smoke

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 .DS_Store
 npm-debug.log*
+.claude/settings.local.json

--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ claude mcp add --scope user rust-lldb -- "$PWD/index.js"
 claude mcp list | grep rust-lldb   # should show "✓ Connected"
 ```
 
+The name `rust-lldb` in that command is load-bearing: the bundled skill
+hardcodes `mcp__rust-lldb__*` as the tool prefix. If you register under a
+different name, the skill won't see the tools.
+
 Start a fresh Claude Code session; `mcp__rust-lldb__lldb_start`,
 `mcp__rust-lldb__lldb_command`, `mcp__rust-lldb__lldb_restart`, and
 `mcp__rust-lldb__lldb_stop` appear in the toolbox. The tool surface is

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ supported.
 - **`rust-lldb`** on `PATH` — the rustup wrapper that loads Rust
   pretty-printers. Installed with the Rust toolchain.
 - **LLDB 21+** (or Apple's LLDB from Xcode 16+ CLT) — verified by
-  `rust-lldb -b -o "protocol-server start MCP accept:///tmp/probe.sock" -o "protocol-server stop"`
+  `rust-lldb -b -o "protocol-server start MCP accept:///tmp/probe.sock" -o "protocol-server stop MCP"`
   emitting `MCP server started …`. Older LLDBs lack `protocol-server` and
   won't work.
 

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,47 @@
+{
+    "$schema": "https://biomejs.dev/schemas/2.4.12/schema.json",
+    "vcs": {
+        "enabled": true,
+        "clientKind": "git",
+        "useIgnoreFile": true
+    },
+    "files": {
+        "includes": [
+            "**/*.js",
+            "**/*.json",
+            "!**/node_modules",
+            "!**/package-lock.json",
+            "!**/skills/**/*.md"
+        ]
+    },
+    "formatter": {
+        "enabled": true,
+        "indentStyle": "space",
+        "indentWidth": 4,
+        "lineEnding": "lf",
+        "lineWidth": 100
+    },
+    "linter": {
+        "enabled": true,
+        "rules": {
+            "recommended": true,
+            "correctness": {
+                "noUnusedImports": "error"
+            }
+        }
+    },
+    "javascript": {
+        "formatter": {
+            "quoteStyle": "single",
+            "semicolons": "always",
+            "trailingCommas": "all",
+            "arrowParentheses": "always"
+        }
+    },
+    "overrides": [
+        {
+            "includes": ["package.json"],
+            "formatter": { "indentWidth": 2 }
+        }
+    ]
+}

--- a/index.js
+++ b/index.js
@@ -221,6 +221,9 @@ async function startSession({ binary, core, preload, socket_wait_ms }) {
     }
 
     const id = nextSessionId++;
+    // Hardcoded /tmp (not os.tmpdir()): macOS TMPDIR lives under /var/folders/.../T/,
+    // which can push past the 104-byte sun_path limit on Unix sockets. /tmp exists
+    // and is writable on both macOS and Linux, and keeps the full socket path short.
     const socketPath = `/tmp/rust-lldb-mcp.${process.pid}.${nextSocketCounter++}.sock`;
 
     // Best-effort: remove any stale socket file at the target path.

--- a/index.js
+++ b/index.js
@@ -19,17 +19,13 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
 
+import { classifyCommand, LldbError, resolveSocketWaitMs, shellQuote } from './lib.js';
+
 const MAX_SESSIONS = 8;
-// Default socket-wait budget for lldb's MCP protocol-server to open its
-// Unix socket. Preload commands run *before* the socket appears, so a
-// slow `run` against a debug build can easily need more than a couple
-// of seconds. The default is a fast-fail ceiling for well-behaved
-// invocations; override via `socket_wait_ms` on `lldb_start` or the
-// `LLDB_MCP_SOCKET_WAIT_MS` env var when preload is heavy.
-const SOCKET_WAIT_MS_DEFAULT = 5000;
-const SOCKET_WAIT_MS_MIN = 500;
-const SOCKET_WAIT_MS_MAX = 120000;
-const SOCKET_WAIT_MS_ENV = 'LLDB_MCP_SOCKET_WAIT_MS';
+// Socket-wait budget for lldb's MCP protocol-server — argument > env var
+// > default — plus clamping lives in lib.js. Override via `socket_wait_ms`
+// on `lldb_start` or the `LLDB_MCP_SOCKET_WAIT_MS` env var when preload
+// is heavy.
 const SOCKET_POLL_MS = 50;
 const LLDB_CMD_TIMEOUT_MS = 60000;
 const INITIALIZE_TIMEOUT_MS = 5000;
@@ -37,14 +33,6 @@ const STOP_SIGTERM_WAIT_MS = 500;
 const OUTPUT_BUDGET_CHARS = 20000;
 
 const log = (...args) => console.error('[rust-lldb-mcp]', ...args);
-
-class LldbError extends Error {
-    constructor(code, message, details) {
-        super(message);
-        this.code = code;
-        this.details = details;
-    }
-}
 
 const sessions = new Map(); // id -> Session
 let nextSessionId = 1;
@@ -160,31 +148,6 @@ async function waitForSocket(path, child, timeoutMs) {
         'socket_never_appeared',
         `LLDB MCP socket ${path} did not appear within ${timeoutMs}ms`,
     );
-}
-
-// Resolve the effective socket-wait timeout: explicit argument wins,
-// then env var, then the built-in default. Invalid values throw with
-// `invalid_request` so the caller sees their own mistake immediately
-// instead of silently falling back. Valid values are clamped to
-// [SOCKET_WAIT_MS_MIN, SOCKET_WAIT_MS_MAX] so a pathological override
-// (0, Infinity, NaN, negative) can't stall the orchestrator.
-function resolveSocketWaitMs(arg) {
-    const pick = (raw, source) => {
-        if (raw === undefined || raw === null || raw === '') return null;
-        const n = typeof raw === 'number' ? raw : Number(raw);
-        if (!Number.isFinite(n) || !Number.isInteger(n) || n <= 0) {
-            throw new LldbError(
-                'invalid_request',
-                `${source} must be a positive integer number of milliseconds, got ${JSON.stringify(raw)}`,
-            );
-        }
-        return Math.min(SOCKET_WAIT_MS_MAX, Math.max(SOCKET_WAIT_MS_MIN, n));
-    };
-    const fromArg = pick(arg, 'socket_wait_ms');
-    if (fromArg !== null) return fromArg;
-    const fromEnv = pick(process.env[SOCKET_WAIT_MS_ENV], SOCKET_WAIT_MS_ENV);
-    if (fromEnv !== null) return fromEnv;
-    return SOCKET_WAIT_MS_DEFAULT;
 }
 
 async function fileExists(path) {
@@ -459,13 +422,6 @@ async function probeStopSummary(session) {
     return firstLine;
 }
 
-function shellQuote(s) {
-    // LLDB's command parser accepts single-quoted paths. We only need to
-    // handle embedded single quotes.
-    if (/^[A-Za-z0-9_./-]+$/.test(s)) return s;
-    return `'${String(s).replaceAll("'", "'\\''")}'`;
-}
-
 async function runLldbCommand(session, command) {
     const result = await session.request('tools/call', {
         name: 'lldb_command',
@@ -479,58 +435,6 @@ async function runLldbCommand(session, command) {
         }
     }
     return output;
-}
-
-// First word of an LLDB command line, lowercase, with leading whitespace trimmed.
-// Used to gate a small set of commands that hang when invoked via LLDB's MCP
-// lldb_command tool. Pattern tolerates leading whitespace and `command <verb>`
-// prefixes (a common LLDB alias style) by looking at the first non-whitespace
-// token after any `command `/`co ` aliases.
-const HANG_VERBS = new Set([
-    'run', 'r', 'continue', 'c', 'process', 'thread', 'step', 's', 'next', 'n',
-    'stepi', 'si', 'nexti', 'ni', 'finish', 'f', 'jump', 'j',
-    'expression', 'expr', 'p', 'print', 'call',
-]);
-// Subset of the above that are always harmless — we only block the ones that
-// actually resume the inferior. Anything in this allowlist passes through.
-const SAFE_SUBCOMMANDS = {
-    process: new Set(['status', 'handle', 'save-core', 'signal', 'plugin']),
-    thread: new Set([
-        'backtrace', 'bt', 'info', 'list', 'select', 'until', 'return', 'plan',
-    ]),
-};
-const ALWAYS_SAFE = new Set([
-    'expression', 'expr', 'p', 'print', 'call', // reads are fine; function calls can hang, but blocking them all is too conservative
-]);
-
-function classifyCommand(raw) {
-    let s = String(raw || '').trim();
-    if (!s) return 'empty';
-    const tokens = s.split(/\s+/);
-    const verb = tokens[0].toLowerCase();
-    if (!HANG_VERBS.has(verb)) return 'safe';
-    if (ALWAYS_SAFE.has(verb)) return 'safe';
-    const sub = (tokens[1] || '').toLowerCase();
-    const subSafe = SAFE_SUBCOMMANDS[verb];
-    if (subSafe && subSafe.has(sub)) return 'safe';
-    // Unambiguous hang cases.
-    if (verb === 'run' || verb === 'r') return 'hang';
-    if (verb === 'continue' || verb === 'c') return 'hang';
-    if (verb === 'step' || verb === 's' || verb === 'stepi' || verb === 'si') return 'hang';
-    if (verb === 'next' || verb === 'n' || verb === 'nexti' || verb === 'ni') return 'hang';
-    if (verb === 'finish' || verb === 'jump' || verb === 'j') return 'hang';
-    if (verb === 'process') {
-        if (sub === 'launch' || sub === 'continue' || sub === 'kill' || sub === 'interrupt' ||
-            sub === 'attach' || sub === 'detach' || sub === 'connect') return 'hang';
-        return 'safe'; // conservative: unknown process subcmd, let LLDB decide
-    }
-    if (verb === 'thread') {
-        if (sub === 'step-in' || sub === 'step-over' || sub === 'step-out' || sub === 'step-inst' ||
-            sub === 'step-over-inst' || sub === 'step-scripted' || sub === 'continue' ||
-            sub === 'jump' || sub === 'until') return 'hang';
-        return 'safe';
-    }
-    return 'safe';
 }
 
 async function commandSession({ session_id, command }) {

--- a/index.js
+++ b/index.js
@@ -10,10 +10,10 @@
 // stdout is owned by the outer MCP SDK. All logs go to stderr.
 
 import { spawn } from 'node:child_process';
+import { constants as fsConstants } from 'node:fs';
+import { access, unlink } from 'node:fs/promises';
 import { createConnection } from 'node:net';
 import { PassThrough } from 'node:stream';
-import { access, unlink } from 'node:fs/promises';
-import { constants as fsConstants } from 'node:fs';
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
@@ -22,10 +22,13 @@ import { z } from 'zod';
 import { classifyCommand, LldbError, resolveSocketWaitMs, shellQuote } from './lib.js';
 
 const MAX_SESSIONS = 8;
-// Socket-wait budget for lldb's MCP protocol-server — argument > env var
-// > default — plus clamping lives in lib.js. Override via `socket_wait_ms`
-// on `lldb_start` or the `LLDB_MCP_SOCKET_WAIT_MS` env var when preload
-// is heavy.
+// Default socket-wait budget for lldb's MCP protocol-server to open its
+// Unix socket. Preload commands run *before* the socket appears, so a
+// slow `run` against a debug build can easily need more than a couple
+// of seconds. The default is a fast-fail ceiling for well-behaved
+// invocations; override via `socket_wait_ms` on `lldb_start` or the
+// `LLDB_MCP_SOCKET_WAIT_MS` env var when preload is heavy. The actual
+// resolution (argument > env > default) plus clamping lives in lib.js.
 const SOCKET_POLL_MS = 50;
 const LLDB_CMD_TIMEOUT_MS = 60000;
 const INITIALIZE_TIMEOUT_MS = 5000;
@@ -92,12 +95,14 @@ class Session {
             const timer = setTimeout(() => {
                 if (this.pending.has(id)) {
                     this.pending.delete(id);
-                    reject(new LldbError('timeout', `LLDB ${method} timed out after ${timeoutMs}ms`));
+                    reject(
+                        new LldbError('timeout', `LLDB ${method} timed out after ${timeoutMs}ms`),
+                    );
                 }
             }, timeoutMs);
             this.pending.set(id, { resolve, reject, timer });
             try {
-                this.socket.write(JSON.stringify(payload) + '\n');
+                this.socket.write(`${JSON.stringify(payload)}\n`);
             } catch (err) {
                 clearTimeout(timer);
                 this.pending.delete(id);
@@ -110,7 +115,7 @@ class Session {
         if (this.dead) return;
         const payload = { jsonrpc: '2.0', method, params };
         try {
-            this.socket.write(JSON.stringify(payload) + '\n');
+            this.socket.write(`${JSON.stringify(payload)}\n`);
         } catch (err) {
             log(`session ${this.id}: notify write failed:`, err.message);
         }
@@ -119,7 +124,7 @@ class Session {
     markDead(reason) {
         if (this.dead) return;
         this.dead = true;
-        for (const [id, entry] of this.pending) {
+        for (const [_id, entry] of this.pending) {
             if (entry.timer) clearTimeout(entry.timer);
             entry.reject(new LldbError('lldb_crashed', reason || 'LLDB session exited'));
         }
@@ -142,7 +147,7 @@ async function waitForSocket(path, child, timeoutMs) {
         } catch {
             // not there yet
         }
-        await new Promise(r => setTimeout(r, SOCKET_POLL_MS));
+        await new Promise((r) => setTimeout(r, SOCKET_POLL_MS));
     }
     throw new LldbError(
         'socket_never_appeared',
@@ -161,10 +166,7 @@ async function fileExists(path) {
 
 async function startSession({ binary, core, preload, socket_wait_ms }) {
     if (!binary && !core) {
-        throw new LldbError(
-            'invalid_request',
-            'lldb_start requires at least one of: binary, core',
-        );
+        throw new LldbError('invalid_request', 'lldb_start requires at least one of: binary, core');
     }
     if (binary && !(await fileExists(binary))) {
         throw new LldbError('binary_not_found', `binary does not exist: ${binary}`);
@@ -243,7 +245,9 @@ async function startSession({ binary, core, preload, socket_wait_ms }) {
     try {
         await waitForSocket(socketPath, child, socketWaitMs);
     } catch (err) {
-        try { child.kill('SIGKILL'); } catch {}
+        try {
+            child.kill('SIGKILL');
+        } catch {}
         stdinKeepalive.destroy();
         await unlink(socketPath).catch(() => {});
         if (spawnError) {
@@ -264,7 +268,9 @@ async function startSession({ binary, core, preload, socket_wait_ms }) {
             });
         });
     } catch (err) {
-        try { child.kill('SIGKILL'); } catch {}
+        try {
+            child.kill('SIGKILL');
+        } catch {}
         stdinKeepalive.destroy();
         await unlink(socketPath).catch(() => {});
         throw new LldbError(
@@ -279,8 +285,9 @@ async function startSession({ binary, core, preload, socket_wait_ms }) {
     socket.setEncoding('utf8');
     socket.on('data', (chunk) => {
         session.buffer += chunk;
-        let newlineIdx;
-        while ((newlineIdx = session.buffer.indexOf('\n')) !== -1) {
+        while (true) {
+            const newlineIdx = session.buffer.indexOf('\n');
+            if (newlineIdx === -1) break;
             const line = session.buffer.slice(0, newlineIdx);
             session.buffer = session.buffer.slice(newlineIdx + 1);
             if (!line.trim()) continue;
@@ -391,10 +398,11 @@ async function probeStopSummary(session) {
     } catch {
         return 'unknown';
     }
-    const firstLine = (statusOut || '')
-        .split('\n')
-        .map(l => l.trim())
-        .find(l => l.length > 0) || '';
+    const firstLine =
+        (statusOut || '')
+            .split('\n')
+            .map((l) => l.trim())
+            .find((l) => l.length > 0) || '';
     if (!firstLine) return 'target loaded (no process)';
     // "error: invalid process" (LLDB 21), "error: Command requires a current
     // process." (Apple LLDB) — both mean "target is loaded but nothing has run
@@ -409,10 +417,11 @@ async function probeStopSummary(session) {
         let frameDetail = '';
         try {
             const frameOut = await runLldbCommand(session, 'frame info');
-            const frameLine = (frameOut || '')
-                .split('\n')
-                .map(l => l.trim())
-                .find(l => l.length > 0) || '';
+            const frameLine =
+                (frameOut || '')
+                    .split('\n')
+                    .map((l) => l.trim())
+                    .find((l) => l.length > 0) || '';
             if (frameLine) frameDetail = ` — ${frameLine}`;
         } catch {
             // Leave frameDetail empty on error.
@@ -466,11 +475,19 @@ async function commandSession({ session_id, command }) {
 async function teardownSession(session) {
     if (session.closing) return;
     session.closing = true;
-    try { session.socket.end(); } catch {}
-    try { session.socket.destroy(); } catch {}
-    try { session.stdinKeepalive?.destroy(); } catch {}
+    try {
+        session.socket.end();
+    } catch {}
+    try {
+        session.socket.destroy();
+    } catch {}
+    try {
+        session.stdinKeepalive?.destroy();
+    } catch {}
     if (session.child && session.child.exitCode === null) {
-        try { session.child.kill('SIGTERM'); } catch {}
+        try {
+            session.child.kill('SIGTERM');
+        } catch {}
         const stopped = await new Promise((resolve) => {
             const t = setTimeout(() => resolve(false), STOP_SIGTERM_WAIT_MS);
             session.child.once('exit', () => {
@@ -479,7 +496,9 @@ async function teardownSession(session) {
             });
         });
         if (!stopped) {
-            try { session.child.kill('SIGKILL'); } catch {}
+            try {
+                session.child.kill('SIGKILL');
+            } catch {}
         }
     }
     await unlink(session.socketPath).catch(() => {});
@@ -523,9 +542,7 @@ async function restartSession({ session_id, preload }) {
     sessions.delete(session_id);
     await teardownSession(session);
 
-    const nextPreload = preload !== undefined && preload !== null
-        ? preload
-        : prev.preload;
+    const nextPreload = preload !== undefined && preload !== null ? preload : prev.preload;
     const spawnArgs = {
         binary: prev.binary ?? undefined,
         core: prev.core ?? undefined,
@@ -567,9 +584,14 @@ async function shutdownAll() {
 // MCP server boilerplate
 
 function toToolError(err) {
-    const payload = err instanceof LldbError
-        ? { code: err.code, message: err.message, ...(err.details ? { details: err.details } : {}) }
-        : { code: 'internal_error', message: err?.message || String(err) };
+    const payload =
+        err instanceof LldbError
+            ? {
+                  code: err.code,
+                  message: err.message,
+                  ...(err.details ? { details: err.details } : {}),
+              }
+            : { code: 'internal_error', message: err?.message || String(err) };
     return {
         isError: true,
         content: [{ type: 'text', text: JSON.stringify(payload) }],
@@ -608,7 +630,7 @@ server.registerTool(
                 .positive()
                 .optional()
                 .describe(
-                    'Milliseconds to wait for lldb\'s MCP socket to appear after preload finishes. Default 5000; clamped to [500, 120000]. LLDB_MCP_SOCKET_WAIT_MS env var is a fallback when this argument is absent.',
+                    "Milliseconds to wait for lldb's MCP socket to appear after preload finishes. Default 5000; clamped to [500, 120000]. LLDB_MCP_SOCKET_WAIT_MS env var is a fallback when this argument is absent.",
                 ),
         },
     },
@@ -626,10 +648,12 @@ server.registerTool(
     'lldb_command',
     {
         description:
-            'Debugger command: run any LLDB command in an existing session to set breakpoints, inspect stack frames, read variables, disassemble, or query process state. The command string is passed to LLDB exactly as typed at the (lldb) prompt. Returns { output, truncated?, dropped_chars? }. Note: LLDB\'s `breakpoint set --condition` evaluator is unreliable for Rust struct-field access (e.g. `self.field == 42` silently evaluates-true on every hit); prefer `--ignore-count N`, `--one-shot true`, `$__lldb_hitcount == N`, or plain register/address equality.',
+            "Debugger command: run any LLDB command in an existing session to set breakpoints, inspect stack frames, read variables, disassemble, or query process state. The command string is passed to LLDB exactly as typed at the (lldb) prompt. Returns { output, truncated?, dropped_chars? }. Note: LLDB's `breakpoint set --condition` evaluator is unreliable for Rust struct-field access (e.g. `self.field == 42` silently evaluates-true on every hit); prefer `--ignore-count N`, `--one-shot true`, `$__lldb_hitcount == N`, or plain register/address equality.",
         inputSchema: {
             session_id: z.number().int().describe('Session id returned by lldb_start.'),
-            command: z.string().describe('LLDB command string (e.g. "bt 10", "frame variable foo").'),
+            command: z
+                .string()
+                .describe('LLDB command string (e.g. "bt 10", "frame variable foo").'),
         },
     },
     async (args) => {
@@ -667,12 +691,15 @@ server.registerTool(
         description:
             'Debugger restart: tear down an existing rust-lldb session and spawn a fresh one against the same binary or core dump, optionally with a new preload (e.g. "move the breakpoint, re-run to the next site"). Reuses the previous preload when `preload` is omitted. Always returns a fresh session_id — the old id is invalidated. Use this instead of lldb_stop + lldb_start when you need to resume execution past breakpoint hits, since process-executing commands (continue, step, run) hang if issued via lldb_command.',
         inputSchema: {
-            session_id: z.number().int().describe('Session id returned by a prior lldb_start/lldb_restart.'),
+            session_id: z
+                .number()
+                .int()
+                .describe('Session id returned by a prior lldb_start/lldb_restart.'),
             preload: z
                 .array(z.string())
                 .optional()
                 .describe(
-                    'Optional new preload for the respawned session. When omitted, the previous session\'s preload is reused verbatim.',
+                    "Optional new preload for the respawned session. When omitted, the previous session's preload is reused verbatim.",
                 ),
         },
     },
@@ -699,7 +726,9 @@ async function shutdown(reason) {
     } catch (err) {
         log('shutdownAll error:', err);
     }
-    try { await server.close(); } catch {}
+    try {
+        await server.close();
+    } catch {}
     // Give async logs a tick to flush.
     setImmediate(() => process.exit(0));
 }

--- a/lib.js
+++ b/lib.js
@@ -1,0 +1,140 @@
+// Pure helpers shared by index.js and the test suite. No side effects on
+// import — keep it that way so `node --test` can require this module
+// without spinning up the MCP server.
+
+export const SOCKET_WAIT_MS_DEFAULT = 5000;
+export const SOCKET_WAIT_MS_MIN = 500;
+export const SOCKET_WAIT_MS_MAX = 120000;
+export const SOCKET_WAIT_MS_ENV = 'LLDB_MCP_SOCKET_WAIT_MS';
+
+export class LldbError extends Error {
+    constructor(code, message, details) {
+        super(message);
+        this.code = code;
+        this.details = details;
+    }
+}
+
+// Resolve the effective socket-wait timeout: explicit argument wins,
+// then env var, then the built-in default. Invalid values throw with
+// `invalid_request` so the caller sees their own mistake immediately
+// instead of silently falling back. Valid values are clamped to
+// [SOCKET_WAIT_MS_MIN, SOCKET_WAIT_MS_MAX] so a pathological override
+// (0, Infinity, NaN, negative) can't stall the orchestrator.
+export function resolveSocketWaitMs(arg, env = process.env) {
+    const pick = (raw, source) => {
+        if (raw === undefined || raw === null || raw === '') return null;
+        const n = typeof raw === 'number' ? raw : Number(raw);
+        if (!Number.isFinite(n) || !Number.isInteger(n) || n <= 0) {
+            throw new LldbError(
+                'invalid_request',
+                `${source} must be a positive integer number of milliseconds, got ${JSON.stringify(raw)}`,
+            );
+        }
+        return Math.min(SOCKET_WAIT_MS_MAX, Math.max(SOCKET_WAIT_MS_MIN, n));
+    };
+    const fromArg = pick(arg, 'socket_wait_ms');
+    if (fromArg !== null) return fromArg;
+    const fromEnv = pick(env[SOCKET_WAIT_MS_ENV], SOCKET_WAIT_MS_ENV);
+    if (fromEnv !== null) return fromEnv;
+    return SOCKET_WAIT_MS_DEFAULT;
+}
+
+export function shellQuote(s) {
+    // LLDB's command parser accepts single-quoted paths. We only need to
+    // handle embedded single quotes.
+    if (/^[A-Za-z0-9_./-]+$/.test(s)) return s;
+    return `'${String(s).replaceAll("'", "'\\''")}'`;
+}
+
+// First word of an LLDB command line, lowercase, with leading whitespace trimmed.
+// Used to gate a small set of commands that hang when invoked via LLDB's MCP
+// lldb_command tool. Pattern tolerates leading whitespace and `command <verb>`
+// prefixes (a common LLDB alias style) by looking at the first non-whitespace
+// token after any `command `/`co ` aliases.
+export const HANG_VERBS = new Set([
+    'run',
+    'r',
+    'continue',
+    'c',
+    'process',
+    'thread',
+    'step',
+    's',
+    'next',
+    'n',
+    'stepi',
+    'si',
+    'nexti',
+    'ni',
+    'finish',
+    'f',
+    'jump',
+    'j',
+    'expression',
+    'expr',
+    'p',
+    'print',
+    'call',
+]);
+// Subset of the above that are always harmless — we only block the ones that
+// actually resume the inferior. Anything in this allowlist passes through.
+export const SAFE_SUBCOMMANDS = {
+    process: new Set(['status', 'handle', 'save-core', 'signal', 'plugin']),
+    thread: new Set(['backtrace', 'bt', 'info', 'list', 'select', 'until', 'return', 'plan']),
+};
+export const ALWAYS_SAFE = new Set([
+    // reads are fine; function calls can hang, but blocking them all is too conservative
+    'expression',
+    'expr',
+    'p',
+    'print',
+    'call',
+]);
+
+export function classifyCommand(raw) {
+    const s = String(raw || '').trim();
+    if (!s) return 'empty';
+    const tokens = s.split(/\s+/);
+    const verb = tokens[0].toLowerCase();
+    if (!HANG_VERBS.has(verb)) return 'safe';
+    if (ALWAYS_SAFE.has(verb)) return 'safe';
+    const sub = (tokens[1] || '').toLowerCase();
+    const subSafe = SAFE_SUBCOMMANDS[verb];
+    if (subSafe?.has(sub)) return 'safe';
+    // Unambiguous hang cases.
+    if (verb === 'run' || verb === 'r') return 'hang';
+    if (verb === 'continue' || verb === 'c') return 'hang';
+    if (verb === 'step' || verb === 's' || verb === 'stepi' || verb === 'si') return 'hang';
+    if (verb === 'next' || verb === 'n' || verb === 'nexti' || verb === 'ni') return 'hang';
+    if (verb === 'finish' || verb === 'jump' || verb === 'j') return 'hang';
+    if (verb === 'process') {
+        if (
+            sub === 'launch' ||
+            sub === 'continue' ||
+            sub === 'kill' ||
+            sub === 'interrupt' ||
+            sub === 'attach' ||
+            sub === 'detach' ||
+            sub === 'connect'
+        )
+            return 'hang';
+        return 'safe'; // conservative: unknown process subcmd, let LLDB decide
+    }
+    if (verb === 'thread') {
+        if (
+            sub === 'step-in' ||
+            sub === 'step-over' ||
+            sub === 'step-out' ||
+            sub === 'step-inst' ||
+            sub === 'step-over-inst' ||
+            sub === 'step-scripted' ||
+            sub === 'continue' ||
+            sub === 'jump' ||
+            sub === 'until'
+        )
+            return 'hang';
+        return 'safe';
+    }
+    return 'safe';
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,198 @@
 {
-  "name": "lldb-mcp-orchestrator",
+  "name": "rust-lldb-mcp",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "lldb-mcp-orchestrator",
+      "name": "rust-lldb-mcp",
       "version": "0.1.0",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.0.0"
+        "@modelcontextprotocol/sdk": "1.29.0"
       },
       "bin": {
-        "lldb-mcp-orchestrator": "index.js"
+        "rust-lldb-mcp": "index.js"
+      },
+      "devDependencies": {
+        "@biomejs/biome": "2.4.12"
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.12.tgz",
+      "integrity": "sha512-Rro7adQl3NLq/zJCIL98eElXKI8eEiBtoeu5TbXF/U3qbjuSc7Jb5rjUbeHHcquDWeSf3HnGP7XI5qGrlRk/pA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "2.4.12",
+        "@biomejs/cli-darwin-x64": "2.4.12",
+        "@biomejs/cli-linux-arm64": "2.4.12",
+        "@biomejs/cli-linux-arm64-musl": "2.4.12",
+        "@biomejs/cli-linux-x64": "2.4.12",
+        "@biomejs/cli-linux-x64-musl": "2.4.12",
+        "@biomejs/cli-win32-arm64": "2.4.12",
+        "@biomejs/cli-win32-x64": "2.4.12"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.12.tgz",
+      "integrity": "sha512-BnMU4Pc3ciEVteVpZ0BK33MLr7X57F5w1dwDLDn+/iy/yTrA4Q/N2yftidFtsA4vrDh0FMXDpacNV/Tl3fbmng==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.12.tgz",
+      "integrity": "sha512-x9uJ0bI1rJsWICp3VH8w/5PnAVD3A7SqzDpbrfoUQX1QyWrK5jSU4fRLo/wSgGeplCivbxBRKmt5Xq4/nWvq8A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.12.tgz",
+      "integrity": "sha512-tOwuCuZZtKi1jVzbk/5nXmIsziOB6yqN8c9r9QM0EJYPU6DpQWf11uBOSCfFKKM4H3d9ZoarvlgMfbcuD051Pw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.12.tgz",
+      "integrity": "sha512-FhfpkAAlKL6kwvcVap0Hgp4AhZmtd3YImg0kK1jd7C/aSoh4SfsB2f++yG1rU0lr8Y5MCFJrcSkmssiL9Xnnig==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.12.tgz",
+      "integrity": "sha512-8pFeAnLU9QdW9jCIslB/v82bI0lhBmz2ZAKc8pVMFPO0t0wAHsoEkrUQUbMkIorTRIjbqyNZHA3lEXavsPWYSw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.12.tgz",
+      "integrity": "sha512-dwTIgZrGutzhkQCuvHynCkyW6hJxUuyZqKKO0YNfaS2GUoRO+tOvxXZqZB6SkWAOdfZTzwaw8IEdUnIkHKHoew==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.12.tgz",
+      "integrity": "sha512-B0DLnx0vA9ya/3v7XyCaP+/lCpnbWbMOfUFFve+xb5OxyYvdHaS55YsSddr228Y+JAFk58agCuZTsqNiw2a6ig==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.12.tgz",
+      "integrity": "sha512-yMckRzTyZ83hkk8iDFWswqSdU8tvZxspJKnYNh7JZr/zhZNOlzH13k4ecboU6MurKExCe2HUkH75pGI/O2JwGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
       }
     },
     "node_modules/@hono/node-server": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,16 @@
   "engines": {
     "node": ">=20"
   },
+  "scripts": {
+    "lint": "biome ci .",
+    "format": "biome format --write .",
+    "test": "node --test test/*.test.js",
+    "smoke": "node smoke-test.js"
+  },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.0.0"
+    "@modelcontextprotocol/sdk": "1.29.0"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "2.4.12"
   }
 }

--- a/skills/rust-debug/install.md
+++ b/skills/rust-debug/install.md
@@ -12,7 +12,7 @@ LLDB with MCP support (`protocol-server start MCP` accepted, `accept:///` Unix-s
 One-command check on your machine:
 
 ```bash
-lldb -b -o "protocol-server start MCP accept:///tmp/lldb-probe.sock" -o "protocol-server stop"
+rust-lldb -b -o "protocol-server start MCP accept:///tmp/lldb-probe.sock" -o "protocol-server stop MCP"
 ```
 
 If the output contains `MCP server started …`, you're fine — skip to the orchestrator section at the bottom. If you see `error: 'protocol-server' is not a valid command`, follow the platform section.

--- a/smoke-test.js
+++ b/smoke-test.js
@@ -3,10 +3,10 @@
 // the three tools plus a few failure modes.
 
 import { spawn } from 'node:child_process';
-import { fileURLToPath } from 'node:url';
-import { dirname, join } from 'node:path';
 import { mkdtemp, readdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -21,7 +21,7 @@ const info = (s) => console.log(color('36', '·'), s);
 
 async function listSocketFiles() {
     const files = await readdir('/tmp');
-    return files.filter(f => f.startsWith('rust-lldb-mcp.'));
+    return files.filter((f) => f.startsWith('rust-lldb-mcp.'));
 }
 
 // Compile a tiny C fixture that sleeps longer than the default
@@ -37,7 +37,7 @@ async function buildSlowFixture(sleepSeconds) {
     );
     await new Promise((resolve, reject) => {
         const cc = spawn('cc', ['-g', src, '-o', bin], { stdio: 'inherit' });
-        cc.on('exit', (code) => code === 0 ? resolve() : reject(new Error(`cc exited ${code}`)));
+        cc.on('exit', (code) => (code === 0 ? resolve() : reject(new Error(`cc exited ${code}`))));
         cc.on('error', reject);
     });
     return {
@@ -54,7 +54,7 @@ async function countLldbProcs() {
         // string (e.g. `.../rust-lldb-mcp/index.js`).
         const c = spawn('pgrep', ['-f', 'protocol-server start MCP']);
         let out = '';
-        c.stdout.on('data', d => out += d);
+        c.stdout.on('data', (d) => (out += d));
         c.on('exit', () => resolve(out.trim().split('\n').filter(Boolean).length));
         c.on('error', () => resolve(0));
     });
@@ -70,13 +70,18 @@ function startOrchestrator() {
 
     child.stdout.on('data', (chunk) => {
         buffer += chunk;
-        let nl;
-        while ((nl = buffer.indexOf('\n')) !== -1) {
+        while (true) {
+            const nl = buffer.indexOf('\n');
+            if (nl === -1) break;
             const line = buffer.slice(0, nl);
             buffer = buffer.slice(nl + 1);
             if (!line.trim()) continue;
             let msg;
-            try { msg = JSON.parse(line); } catch { continue; }
+            try {
+                msg = JSON.parse(line);
+            } catch {
+                continue;
+            }
             if (msg.id !== undefined && pending.has(msg.id)) {
                 const { resolve, reject } = pending.get(msg.id);
                 pending.delete(msg.id);
@@ -95,16 +100,22 @@ function startOrchestrator() {
                 reject(new Error(`request ${method} timed out after ${timeoutMs}ms`));
             }, timeoutMs);
             pending.set(id, {
-                resolve: (r) => { clearTimeout(t); resolve(r); },
-                reject: (e) => { clearTimeout(t); reject(e); },
+                resolve: (r) => {
+                    clearTimeout(t);
+                    resolve(r);
+                },
+                reject: (e) => {
+                    clearTimeout(t);
+                    reject(e);
+                },
             });
-            child.stdin.write(JSON.stringify(payload) + '\n');
+            child.stdin.write(`${JSON.stringify(payload)}\n`);
         });
     }
 
     function notify(method, params) {
         const payload = { jsonrpc: '2.0', method, params };
-        child.stdin.write(JSON.stringify(payload) + '\n');
+        child.stdin.write(`${JSON.stringify(payload)}\n`);
     }
 
     return { child, request, notify };
@@ -114,7 +125,11 @@ function parseToolResult(r) {
     if (!r || !Array.isArray(r.content) || !r.content[0]) return { isError: true, raw: r };
     const text = r.content[0].text;
     let parsed;
-    try { parsed = JSON.parse(text); } catch { parsed = { _raw: text }; }
+    try {
+        parsed = JSON.parse(text);
+    } catch {
+        parsed = { _raw: text };
+    }
     return { isError: !!r.isError, value: parsed };
 }
 
@@ -132,98 +147,179 @@ async function main() {
             clientInfo: { name: 'smoke-test', version: '0.0.1' },
         });
         if (init?.serverInfo?.name === 'rust-lldb-mcp') ok('initialize OK');
-        else { bad(`initialize unexpected: ${JSON.stringify(init)}`); failures++; }
+        else {
+            bad(`initialize unexpected: ${JSON.stringify(init)}`);
+            failures++;
+        }
         notify('notifications/initialized', {});
 
         info('tools/list');
         const tools = await request('tools/list', {});
-        const names = (tools?.tools || []).map(t => t.name).sort();
+        const names = (tools?.tools || []).map((t) => t.name).sort();
         const expected = ['lldb_command', 'lldb_restart', 'lldb_start', 'lldb_stop'];
-        if (JSON.stringify(names) === JSON.stringify(expected)) ok(`tools/list: ${names.join(', ')}`);
-        else { bad(`tools/list: got ${JSON.stringify(names)}, want ${JSON.stringify(expected)}`); failures++; }
+        if (JSON.stringify(names) === JSON.stringify(expected))
+            ok(`tools/list: ${names.join(', ')}`);
+        else {
+            bad(`tools/list: got ${JSON.stringify(names)}, want ${JSON.stringify(expected)}`);
+            failures++;
+        }
 
         info('lldb_start with bogus path -> binary_not_found');
-        const bogus = parseToolResult(await request('tools/call', {
-            name: 'lldb_start',
-            arguments: { binary: '/definitely/does/not/exist/xyzzy' },
-        }));
-        if (bogus.isError && bogus.value?.code === 'binary_not_found') ok('binary_not_found surfaced');
-        else { bad(`expected binary_not_found, got: ${JSON.stringify(bogus)}`); failures++; }
+        const bogus = parseToolResult(
+            await request('tools/call', {
+                name: 'lldb_start',
+                arguments: { binary: '/definitely/does/not/exist/xyzzy' },
+            }),
+        );
+        if (bogus.isError && bogus.value?.code === 'binary_not_found')
+            ok('binary_not_found surfaced');
+        else {
+            bad(`expected binary_not_found, got: ${JSON.stringify(bogus)}`);
+            failures++;
+        }
 
         info('lldb_start with /bin/ls');
-        const started = parseToolResult(await request('tools/call', {
-            name: 'lldb_start',
-            arguments: { binary: '/bin/ls' },
-        }, 15000));
-        if (started.isError) { bad(`lldb_start failed: ${JSON.stringify(started)}`); failures++; throw new Error('cannot proceed'); }
+        const started = parseToolResult(
+            await request(
+                'tools/call',
+                {
+                    name: 'lldb_start',
+                    arguments: { binary: '/bin/ls' },
+                },
+                15000,
+            ),
+        );
+        if (started.isError) {
+            bad(`lldb_start failed: ${JSON.stringify(started)}`);
+            failures++;
+            throw new Error('cannot proceed');
+        }
         const sid = started.value?.session_id;
         if (typeof sid === 'number') ok(`lldb_start -> session_id=${sid}`);
-        else { bad(`no session_id: ${JSON.stringify(started)}`); failures++; throw new Error('cannot proceed'); }
-        if (started.value?.binary === '/bin/ls' &&
+        else {
+            bad(`no session_id: ${JSON.stringify(started)}`);
+            failures++;
+            throw new Error('cannot proceed');
+        }
+        if (
+            started.value?.binary === '/bin/ls' &&
             started.value?.preload_count === 0 &&
-            started.value?.stop_summary === 'target loaded (no process)') {
-            ok(`enriched payload: binary=${started.value.binary}, preload_count=${started.value.preload_count}, stop_summary="${started.value.stop_summary}"`);
+            started.value?.stop_summary === 'target loaded (no process)'
+        ) {
+            ok(
+                `enriched payload: binary=${started.value.binary}, preload_count=${started.value.preload_count}, stop_summary="${started.value.stop_summary}"`,
+            );
         } else {
             bad(`enriched payload missing/wrong: ${JSON.stringify(started.value)}`);
             failures++;
         }
 
         info('lldb_command: breakpoint set --name main');
-        const bp = parseToolResult(await request('tools/call', {
-            name: 'lldb_command',
-            arguments: { session_id: sid, command: 'breakpoint set --name main' },
-        }));
-        if (!bp.isError && typeof bp.value?.output === 'string' && /breakpoint/i.test(bp.value.output)) {
+        const bp = parseToolResult(
+            await request('tools/call', {
+                name: 'lldb_command',
+                arguments: { session_id: sid, command: 'breakpoint set --name main' },
+            }),
+        );
+        if (
+            !bp.isError &&
+            typeof bp.value?.output === 'string' &&
+            /breakpoint/i.test(bp.value.output)
+        ) {
             ok(`breakpoint set: ${bp.value.output.split('\n')[0]}`);
-        } else { bad(`breakpoint set unexpected: ${JSON.stringify(bp)}`); failures++; }
+        } else {
+            bad(`breakpoint set unexpected: ${JSON.stringify(bp)}`);
+            failures++;
+        }
 
         info('lldb_command: version');
-        const ver = parseToolResult(await request('tools/call', {
-            name: 'lldb_command',
-            arguments: { session_id: sid, command: 'version' },
-        }));
-        if (!ver.isError && /lldb-/i.test(ver.value?.output || '')) ok(`version: ${ver.value.output.split('\n')[0]}`);
-        else { bad(`version unexpected: ${JSON.stringify(ver)}`); failures++; }
+        const ver = parseToolResult(
+            await request('tools/call', {
+                name: 'lldb_command',
+                arguments: { session_id: sid, command: 'version' },
+            }),
+        );
+        // Apple LLDB reports "lldb-2100.0.16.12"; upstream LLDB 21 reports
+        // "lldb version 21.1.8". Match either shape.
+        if (!ver.isError && /\blldb[- ]/i.test(ver.value?.output || ''))
+            ok(`version: ${ver.value.output.split('\n')[0]}`);
+        else {
+            bad(`version unexpected: ${JSON.stringify(ver)}`);
+            failures++;
+        }
 
         info('lldb_command: run -> process_command_rejected (guardrail)');
-        const rejected = parseToolResult(await request('tools/call', {
-            name: 'lldb_command',
-            arguments: { session_id: sid, command: 'run' },
-        }));
-        if (rejected.isError && rejected.value?.code === 'process_command_rejected') ok('process_command_rejected surfaced');
-        else { bad(`expected process_command_rejected, got: ${JSON.stringify(rejected)}`); failures++; }
+        const rejected = parseToolResult(
+            await request('tools/call', {
+                name: 'lldb_command',
+                arguments: { session_id: sid, command: 'run' },
+            }),
+        );
+        if (rejected.isError && rejected.value?.code === 'process_command_rejected')
+            ok('process_command_rejected surfaced');
+        else {
+            bad(`expected process_command_rejected, got: ${JSON.stringify(rejected)}`);
+            failures++;
+        }
 
         info('lldb_command: process status -> safe (guardrail allowlist)');
-        const procStatus = parseToolResult(await request('tools/call', {
-            name: 'lldb_command',
-            arguments: { session_id: sid, command: 'process status' },
-        }));
-        if (!procStatus.isError && typeof procStatus.value?.output === 'string') ok('process status passed guardrail');
-        else { bad(`process status unexpected: ${JSON.stringify(procStatus)}`); failures++; }
+        const procStatus = parseToolResult(
+            await request('tools/call', {
+                name: 'lldb_command',
+                arguments: { session_id: sid, command: 'process status' },
+            }),
+        );
+        if (!procStatus.isError && typeof procStatus.value?.output === 'string')
+            ok('process status passed guardrail');
+        else {
+            bad(`process status unexpected: ${JSON.stringify(procStatus)}`);
+            failures++;
+        }
 
         info('lldb_command on bogus session_id -> session_not_found');
-        const nofound = parseToolResult(await request('tools/call', {
-            name: 'lldb_command',
-            arguments: { session_id: 9999, command: 'version' },
-        }));
-        if (nofound.isError && nofound.value?.code === 'session_not_found') ok('session_not_found surfaced');
-        else { bad(`expected session_not_found, got: ${JSON.stringify(nofound)}`); failures++; }
+        const nofound = parseToolResult(
+            await request('tools/call', {
+                name: 'lldb_command',
+                arguments: { session_id: 9999, command: 'version' },
+            }),
+        );
+        if (nofound.isError && nofound.value?.code === 'session_not_found')
+            ok('session_not_found surfaced');
+        else {
+            bad(`expected session_not_found, got: ${JSON.stringify(nofound)}`);
+            failures++;
+        }
 
         info('lldb_stop');
-        const stopped = parseToolResult(await request('tools/call', {
-            name: 'lldb_stop',
-            arguments: { session_id: sid },
-        }, 5000));
+        const stopped = parseToolResult(
+            await request(
+                'tools/call',
+                {
+                    name: 'lldb_stop',
+                    arguments: { session_id: sid },
+                },
+                5000,
+            ),
+        );
         if (!stopped.isError && stopped.value?.ok === true) ok('lldb_stop OK');
-        else { bad(`lldb_stop unexpected: ${JSON.stringify(stopped)}`); failures++; }
+        else {
+            bad(`lldb_stop unexpected: ${JSON.stringify(stopped)}`);
+            failures++;
+        }
 
         info('lldb_stop twice -> session_not_found');
-        const stopAgain = parseToolResult(await request('tools/call', {
-            name: 'lldb_stop',
-            arguments: { session_id: sid },
-        }));
-        if (stopAgain.isError && stopAgain.value?.code === 'session_not_found') ok('double-stop surfaced session_not_found');
-        else { bad(`expected session_not_found on double-stop, got: ${JSON.stringify(stopAgain)}`); failures++; }
+        const stopAgain = parseToolResult(
+            await request('tools/call', {
+                name: 'lldb_stop',
+                arguments: { session_id: sid },
+            }),
+        );
+        if (stopAgain.isError && stopAgain.value?.code === 'session_not_found')
+            ok('double-stop surfaced session_not_found');
+        else {
+            bad(`expected session_not_found on double-stop, got: ${JSON.stringify(stopAgain)}`);
+            failures++;
+        }
 
         // --- Restart scenarios ---
         //
@@ -233,10 +329,16 @@ async function main() {
         // with session_not_found.
 
         info('lldb_start (for restart test)');
-        const preRestart = parseToolResult(await request('tools/call', {
-            name: 'lldb_start',
-            arguments: { binary: '/bin/ls' },
-        }, 15000));
+        const preRestart = parseToolResult(
+            await request(
+                'tools/call',
+                {
+                    name: 'lldb_start',
+                    arguments: { binary: '/bin/ls' },
+                },
+                15000,
+            ),
+        );
         const sidA = preRestart.value?.session_id;
         if (typeof sidA !== 'number') {
             bad(`restart setup failed: ${JSON.stringify(preRestart)}`);
@@ -245,20 +347,28 @@ async function main() {
             ok(`restart setup -> session_id=${sidA}`);
 
             info('lldb_restart with new preload -> fresh session_id');
-            const restarted = parseToolResult(await request('tools/call', {
-                name: 'lldb_restart',
-                arguments: {
-                    session_id: sidA,
-                    preload: ['breakpoint set --name main'],
-                },
-            }, 15000));
+            const restarted = parseToolResult(
+                await request(
+                    'tools/call',
+                    {
+                        name: 'lldb_restart',
+                        arguments: {
+                            session_id: sidA,
+                            preload: ['breakpoint set --name main'],
+                        },
+                    },
+                    15000,
+                ),
+            );
             const sidB = restarted.value?.session_id;
-            if (!restarted.isError &&
+            if (
+                !restarted.isError &&
                 typeof sidB === 'number' &&
                 sidB !== sidA &&
                 restarted.value?.previous_session_id === sidA &&
                 restarted.value?.binary === '/bin/ls' &&
-                restarted.value?.preload_count === 1) {
+                restarted.value?.preload_count === 1
+            ) {
                 ok(`lldb_restart -> session_id=${sidB}, previous_session_id=${sidA}`);
             } else {
                 bad(`lldb_restart unexpected: ${JSON.stringify(restarted)}`);
@@ -267,10 +377,12 @@ async function main() {
 
             if (typeof sidB === 'number') {
                 info('lldb_command on old session_id -> session_not_found');
-                const onOld = parseToolResult(await request('tools/call', {
-                    name: 'lldb_command',
-                    arguments: { session_id: sidA, command: 'version' },
-                }));
+                const onOld = parseToolResult(
+                    await request('tools/call', {
+                        name: 'lldb_command',
+                        arguments: { session_id: sidA, command: 'version' },
+                    }),
+                );
                 if (onOld.isError && onOld.value?.code === 'session_not_found') {
                     ok('old session_id rejected after restart');
                 } else {
@@ -279,13 +391,17 @@ async function main() {
                 }
 
                 info('lldb_command on new session: breakpoint list reflects new preload');
-                const bpList = parseToolResult(await request('tools/call', {
-                    name: 'lldb_command',
-                    arguments: { session_id: sidB, command: 'breakpoint list' },
-                }));
-                if (!bpList.isError &&
+                const bpList = parseToolResult(
+                    await request('tools/call', {
+                        name: 'lldb_command',
+                        arguments: { session_id: sidB, command: 'breakpoint list' },
+                    }),
+                );
+                if (
+                    !bpList.isError &&
                     typeof bpList.value?.output === 'string' &&
-                    /main/i.test(bpList.value.output)) {
+                    /main/i.test(bpList.value.output)
+                ) {
                     ok('new session carries restart-provided breakpoint');
                 } else {
                     bad(`breakpoint list unexpected: ${JSON.stringify(bpList)}`);
@@ -293,15 +409,23 @@ async function main() {
                 }
 
                 info('lldb_restart with no preload reuses previous preload');
-                const restarted2 = parseToolResult(await request('tools/call', {
-                    name: 'lldb_restart',
-                    arguments: { session_id: sidB },
-                }, 15000));
+                const restarted2 = parseToolResult(
+                    await request(
+                        'tools/call',
+                        {
+                            name: 'lldb_restart',
+                            arguments: { session_id: sidB },
+                        },
+                        15000,
+                    ),
+                );
                 const sidC = restarted2.value?.session_id;
-                if (!restarted2.isError &&
+                if (
+                    !restarted2.isError &&
                     typeof sidC === 'number' &&
                     sidC !== sidB &&
-                    restarted2.value?.preload_count === 1) {
+                    restarted2.value?.preload_count === 1
+                ) {
                     ok(`lldb_restart (no preload arg) reuses previous -> session_id=${sidC}`);
                 } else {
                     bad(`lldb_restart (reuse) unexpected: ${JSON.stringify(restarted2)}`);
@@ -310,20 +434,32 @@ async function main() {
 
                 if (typeof sidC === 'number') {
                     info(`lldb_stop restart-chain session ${sidC}`);
-                    const stopC = parseToolResult(await request('tools/call', {
-                        name: 'lldb_stop',
-                        arguments: { session_id: sidC },
-                    }, 5000));
-                    if (!stopC.isError && stopC.value?.ok === true) ok('lldb_stop (restart chain) OK');
-                    else { bad(`lldb_stop (restart chain) unexpected: ${JSON.stringify(stopC)}`); failures++; }
+                    const stopC = parseToolResult(
+                        await request(
+                            'tools/call',
+                            {
+                                name: 'lldb_stop',
+                                arguments: { session_id: sidC },
+                            },
+                            5000,
+                        ),
+                    );
+                    if (!stopC.isError && stopC.value?.ok === true)
+                        ok('lldb_stop (restart chain) OK');
+                    else {
+                        bad(`lldb_stop (restart chain) unexpected: ${JSON.stringify(stopC)}`);
+                        failures++;
+                    }
                 }
             }
 
             info('lldb_restart on already-stopped session -> session_not_found');
-            const restartDead = parseToolResult(await request('tools/call', {
-                name: 'lldb_restart',
-                arguments: { session_id: sidA },
-            }));
+            const restartDead = parseToolResult(
+                await request('tools/call', {
+                    name: 'lldb_restart',
+                    arguments: { session_id: sidA },
+                }),
+            );
             if (restartDead.isError && restartDead.value?.code === 'session_not_found') {
                 ok('restart of gone session surfaced session_not_found');
             } else {
@@ -357,13 +493,19 @@ async function main() {
 
         if (fixture) {
             info('lldb_start with slow preload + default timeout -> socket_never_appeared');
-            const tooSlow = parseToolResult(await request('tools/call', {
-                name: 'lldb_start',
-                arguments: {
-                    binary: fixture.binary,
-                    preload: ['run'],
-                },
-            }, 15000));
+            const tooSlow = parseToolResult(
+                await request(
+                    'tools/call',
+                    {
+                        name: 'lldb_start',
+                        arguments: {
+                            binary: fixture.binary,
+                            preload: ['run'],
+                        },
+                    },
+                    15000,
+                ),
+            );
             if (tooSlow.isError && tooSlow.value?.code === 'socket_never_appeared') {
                 ok('socket_never_appeared fires under default timeout');
             } else {
@@ -372,14 +514,20 @@ async function main() {
             }
 
             info('lldb_start with slow preload + raised socket_wait_ms -> session_id');
-            const okSlow = parseToolResult(await request('tools/call', {
-                name: 'lldb_start',
-                arguments: {
-                    binary: fixture.binary,
-                    preload: ['run'],
-                    socket_wait_ms: 15000,
-                },
-            }, 25000));
+            const okSlow = parseToolResult(
+                await request(
+                    'tools/call',
+                    {
+                        name: 'lldb_start',
+                        arguments: {
+                            binary: fixture.binary,
+                            preload: ['run'],
+                            socket_wait_ms: 15000,
+                        },
+                    },
+                    25000,
+                ),
+            );
             const slowSid = okSlow.value?.session_id;
             if (!okSlow.isError && typeof slowSid === 'number') {
                 ok(`slow preload succeeded -> session_id=${slowSid}`);
@@ -390,10 +538,16 @@ async function main() {
 
             if (typeof slowSid === 'number') {
                 info(`lldb_stop slow session ${slowSid}`);
-                const stopSlow = parseToolResult(await request('tools/call', {
-                    name: 'lldb_stop',
-                    arguments: { session_id: slowSid },
-                }, 5000));
+                const stopSlow = parseToolResult(
+                    await request(
+                        'tools/call',
+                        {
+                            name: 'lldb_stop',
+                            arguments: { session_id: slowSid },
+                        },
+                        5000,
+                    ),
+                );
                 if (!stopSlow.isError && stopSlow.value?.ok === true) {
                     ok('lldb_stop (slow session) OK');
                 } else {
@@ -404,28 +558,38 @@ async function main() {
 
             await fixture.cleanup().catch(() => {});
         }
-
     } finally {
         // Close stdin to trigger orchestrator cleanup path.
         child.stdin.end();
         await new Promise((resolve) => {
             const t = setTimeout(() => {
-                try { child.kill('SIGKILL'); } catch {}
+                try {
+                    child.kill('SIGKILL');
+                } catch {}
                 resolve();
             }, 3000);
-            child.once('exit', () => { clearTimeout(t); resolve(); });
+            child.once('exit', () => {
+                clearTimeout(t);
+                resolve();
+            });
         });
     }
 
     // Post-conditions
-    await new Promise(r => setTimeout(r, 300));
+    await new Promise((r) => setTimeout(r, 300));
     const leftover = await listSocketFiles();
     if (leftover.length === 0) ok('no leftover /tmp/rust-lldb-mcp.* sockets');
-    else { bad(`leftover sockets: ${leftover.join(', ')}`); failures++; }
+    else {
+        bad(`leftover sockets: ${leftover.join(', ')}`);
+        failures++;
+    }
 
     const procs = await countLldbProcs();
     if (procs === 0) ok('no orphan rust-lldb processes');
-    else { bad(`${procs} orphan lldb-related process(es) still running`); failures++; }
+    else {
+        bad(`${procs} orphan lldb-related process(es) still running`);
+        failures++;
+    }
 
     if (failures === 0) {
         console.log(color('32', '\nSmoke test: all checks passed.'));

--- a/test/lib.test.js
+++ b/test/lib.test.js
@@ -1,0 +1,213 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+    ALWAYS_SAFE,
+    classifyCommand,
+    HANG_VERBS,
+    LldbError,
+    resolveSocketWaitMs,
+    SAFE_SUBCOMMANDS,
+    SOCKET_WAIT_MS_DEFAULT,
+    SOCKET_WAIT_MS_ENV,
+    SOCKET_WAIT_MS_MAX,
+    SOCKET_WAIT_MS_MIN,
+    shellQuote,
+} from '../lib.js';
+
+describe('classifyCommand', () => {
+    it('returns "empty" for falsy and whitespace-only input', () => {
+        assert.equal(classifyCommand(''), 'empty');
+        assert.equal(classifyCommand('   '), 'empty');
+        assert.equal(classifyCommand(null), 'empty');
+        assert.equal(classifyCommand(undefined), 'empty');
+    });
+
+    it('returns "safe" for commands whose verb is not in HANG_VERBS', () => {
+        for (const cmd of [
+            'version',
+            'bt 10',
+            'frame variable foo',
+            'help',
+            'target list',
+            'breakpoint set --name main',
+            'register read',
+            'memory read 0x1000',
+        ]) {
+            assert.equal(classifyCommand(cmd), 'safe', `expected safe: ${cmd}`);
+        }
+    });
+
+    it('treats every ALWAYS_SAFE verb as safe even when it appears in HANG_VERBS', () => {
+        for (const verb of ALWAYS_SAFE) {
+            assert.ok(
+                HANG_VERBS.has(verb),
+                `ALWAYS_SAFE verb ${verb} should also be in HANG_VERBS`,
+            );
+            assert.equal(classifyCommand(`${verb} something`), 'safe');
+        }
+    });
+
+    it('classifies resumption verbs as "hang"', () => {
+        // Note: 'f' is listed in HANG_VERBS but currently classifies as 'safe' because no branch
+        // below the allowlist catches it. LLDB's `f` is an alias for `frame` (safe), not `finish`,
+        // so the observable result is correct — but the HANG_VERBS membership is misleading.
+        // See follow-up ticket "lib: reconcile classifyCommand HANG_VERBS vs branch coverage".
+        for (const cmd of [
+            'run',
+            'r',
+            'continue',
+            'c',
+            'step',
+            's',
+            'stepi',
+            'si',
+            'next',
+            'n',
+            'nexti',
+            'ni',
+            'finish',
+            'jump 42',
+            'j 42',
+        ]) {
+            assert.equal(classifyCommand(cmd), 'hang', `expected hang: ${cmd}`);
+        }
+    });
+
+    it('allowlists read-only "process" subcommands', () => {
+        for (const sub of SAFE_SUBCOMMANDS.process) {
+            assert.equal(classifyCommand(`process ${sub}`), 'safe');
+        }
+    });
+
+    it('blocks resumption "process" subcommands as "hang"', () => {
+        for (const sub of [
+            'launch',
+            'continue',
+            'kill',
+            'interrupt',
+            'attach',
+            'detach',
+            'connect',
+        ]) {
+            assert.equal(classifyCommand(`process ${sub}`), 'hang');
+        }
+    });
+
+    it('defaults unknown "process" subcommands to "safe" (let LLDB decide)', () => {
+        assert.equal(classifyCommand('process foobar'), 'safe');
+    });
+
+    it('allowlists read-only "thread" subcommands', () => {
+        for (const sub of SAFE_SUBCOMMANDS.thread) {
+            assert.equal(classifyCommand(`thread ${sub}`), 'safe');
+        }
+    });
+
+    it('blocks resumption "thread" subcommands as "hang"', () => {
+        // Note: `thread until` is not tested here — 'until' appears in both SAFE_SUBCOMMANDS.thread
+        // and the thread hang-list, and the allowlist check runs first, so it currently classifies
+        // as 'safe' despite actually resuming the inferior. Tracked in the same follow-up ticket
+        // as the 'f' inconsistency above.
+        for (const sub of [
+            'step-in',
+            'step-over',
+            'step-out',
+            'step-inst',
+            'step-over-inst',
+            'step-scripted',
+            'continue',
+            'jump',
+        ]) {
+            assert.equal(classifyCommand(`thread ${sub}`), 'hang');
+        }
+    });
+
+    it('tolerates leading/trailing whitespace', () => {
+        assert.equal(classifyCommand('   run   '), 'hang');
+        assert.equal(classifyCommand('\t continue '), 'hang');
+        assert.equal(classifyCommand('  version'), 'safe');
+    });
+
+    it('is case-insensitive on the verb', () => {
+        assert.equal(classifyCommand('RUN'), 'hang');
+        assert.equal(classifyCommand('Continue'), 'hang');
+        assert.equal(classifyCommand('Process LAUNCH'), 'hang');
+        assert.equal(classifyCommand('THREAD Step-In'), 'hang');
+    });
+});
+
+describe('resolveSocketWaitMs', () => {
+    const emptyEnv = Object.freeze({});
+
+    it('falls back to the default when neither arg nor env is set', () => {
+        assert.equal(resolveSocketWaitMs(undefined, emptyEnv), SOCKET_WAIT_MS_DEFAULT);
+        assert.equal(resolveSocketWaitMs(null, emptyEnv), SOCKET_WAIT_MS_DEFAULT);
+        assert.equal(resolveSocketWaitMs('', emptyEnv), SOCKET_WAIT_MS_DEFAULT);
+    });
+
+    it('uses env var when arg is absent', () => {
+        assert.equal(resolveSocketWaitMs(undefined, { [SOCKET_WAIT_MS_ENV]: '7500' }), 7500);
+    });
+
+    it('prefers explicit arg over env var', () => {
+        assert.equal(resolveSocketWaitMs(3000, { [SOCKET_WAIT_MS_ENV]: '999999' }), 3000);
+    });
+
+    it('clamps to [MIN, MAX]', () => {
+        assert.equal(resolveSocketWaitMs(1, emptyEnv), SOCKET_WAIT_MS_MIN);
+        assert.equal(resolveSocketWaitMs(999999, emptyEnv), SOCKET_WAIT_MS_MAX);
+        assert.equal(
+            resolveSocketWaitMs(undefined, { [SOCKET_WAIT_MS_ENV]: '1' }),
+            SOCKET_WAIT_MS_MIN,
+        );
+        assert.equal(
+            resolveSocketWaitMs(undefined, { [SOCKET_WAIT_MS_ENV]: '999999' }),
+            SOCKET_WAIT_MS_MAX,
+        );
+    });
+
+    it('rejects non-positive, non-integer, and non-finite values with LldbError', () => {
+        for (const bad of [0, -1, -1000, 1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+            assert.throws(
+                () => resolveSocketWaitMs(bad, emptyEnv),
+                (err) => err instanceof LldbError && err.code === 'invalid_request',
+                `expected invalid_request for ${bad}`,
+            );
+        }
+    });
+
+    it('rejects non-numeric env var values with LldbError citing the env var name', () => {
+        assert.throws(
+            () => resolveSocketWaitMs(undefined, { [SOCKET_WAIT_MS_ENV]: 'banana' }),
+            (err) =>
+                err instanceof LldbError &&
+                err.code === 'invalid_request' &&
+                err.message.includes(SOCKET_WAIT_MS_ENV),
+        );
+    });
+
+    it('accepts numeric strings from the environment', () => {
+        assert.equal(resolveSocketWaitMs(undefined, { [SOCKET_WAIT_MS_ENV]: '12000' }), 12000);
+    });
+});
+
+describe('shellQuote', () => {
+    it('leaves bare-word paths unquoted', () => {
+        assert.equal(shellQuote('foo'), 'foo');
+        assert.equal(shellQuote('target/debug/my-app'), 'target/debug/my-app');
+        assert.equal(shellQuote('/bin/ls'), '/bin/ls');
+        assert.equal(shellQuote('a_b.c-d/e'), 'a_b.c-d/e');
+    });
+
+    it('single-quotes paths with whitespace or shell metacharacters', () => {
+        assert.equal(shellQuote('has space'), "'has space'");
+        assert.equal(shellQuote('path with $var'), "'path with $var'");
+        assert.equal(shellQuote('quotes"inside'), `'quotes"inside'`);
+    });
+
+    it('escapes embedded single quotes using the standard POSIX pattern', () => {
+        assert.equal(shellQuote("o'clock"), `'o'\\''clock'`);
+        assert.equal(shellQuote("''"), `''\\'''\\'''`);
+    });
+});


### PR DESCRIPTION
## Summary

Portability-review fixes for the `rust-lldb` probe commands in `README.md` and `skills/rust-debug/install.md`, a `lib.js` extraction that makes the pure helpers unit-testable, and a first-pass CI + lint setup (Biome, GitHub Actions, Dependabot). See `biome.json` and `.github/workflows/ci.yml` for the final shape.

## Follow-ups

Broadened #1 into a productization tracker; issues #9–#19 cover the outside-CI items (branch protection, 2FA, npm provenance), deferred supply-chain scans, and the latent `classifyCommand` inconsistencies surfaced by the new tests.

## Additional testing beyond CI

CI covers Ubuntu only. The smoke test was also run locally against Apple LLDB 21 (\`lldb-2100.0.16.12\`) to confirm macOS end-to-end behavior — `socket_never_appeared`, restart chain, slow-preload paths.